### PR TITLE
docs(readme): add poem about AI Backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,28 @@ AIBackends is an API server that you can use to integrate AI into your applicati
 
 The project supports running open models locally with Ollama, LM Studio or LlamaCpp. It also supports LLM Gateway, OpenRouter, OpenAI, Anthropic, Google AI Studio, Baseten and ZAI providers.
 
+### A small poem about this project
+
+> *Where prompts become a steady route,*  
+> *and models—local, cloud—salute,*  
+> *AI Backends stands: one honest bridge*  
+> *from “I have an app” to “turn the hinge.”*  
+>  
+> *Hono hums; the schemas hold;*  
+> *each `/api` path is clear and bold:*  
+> *summarize the night, translate the dawn,*  
+> *read the image till the meaning’s drawn.*  
+>  
+> *No sermon on the art of prompts—*  
+> *just OpenAPI’s well-lighted romps;*  
+> *from Ollama’s desk to gateway skies,*  
+> *you pick the mind; the server tries.*
+
 ## Why AI Backends?
 
 The purpose of this project is to make common AI use cases easily accessible to non-coders who want to add AI features to their applications. AIBackends have been tested with popular AI app builder tools like [Bolt.new](https://bolt.new), [v0](https://v0.dev) and [Lovable](https://lovable.dev). You can also use it with [Warp](https://warp.dev), [Cursor](https://cursor.com/), [Claude Code](https://www.anthropic.com/claude-code), [Windsurf](https://windsurf.com/) or [AmpCode](https://ampcode.com/).
 
 Since APIs are ready to use, you don't need to understand prompt engineering. Just prompt the API documentation and you are good to go. For those who want use with online app builders, you need to host AIBackends on your own server. I have tested in Railway and it is a good option.
-
-AI Backends
 
 ## Supported LLM Providers
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a short poem to the README after the opening summary, reflecting the project’s role as a unified API for local and cloud models, Hono/Zod/OpenAPI, and common endpoints. Also removes a stray lone `AI Backends` line that sat between the intro and the Supported LLM Providers section.

## Test plan

- [ ] Skim the rendered README on GitHub for formatting and line breaks in the blockquote.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b110692-cc1b-4378-b5c5-1a082b1aa67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b110692-cc1b-4378-b5c5-1a082b1aa67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

